### PR TITLE
Support Additional CoreDNS Configuration

### DIFF
--- a/jobs/control/spec
+++ b/jobs/control/spec
@@ -446,6 +446,20 @@ properties:
       under the 'cert-manager' Kubernetes namespace.  This can then be referenced
       from an Issuer object.
 
+  coredns.additional-configuration:
+    default: ''
+    description: |
+      Additional configuration to add to the CoreDNS configuration.  This will be
+      properly indented, and must be complete, well-formed, and syntactically valid
+      top-level configuration directives.
+
+      For example, to enable host lookup from bosh-DNS aliases,
+
+          properties:
+            coredns:
+              additional-configuration: |
+                hosts bosh. /etc/hosts/or/something
+
   bootstrap:
     default: ''
     description: |

--- a/jobs/control/templates/k8s/kube-dns.yml
+++ b/jobs/control/templates/k8s/kube-dns.yml
@@ -74,6 +74,7 @@ data:
         loop
         reload
         loadbalance
+<%= (p('coredns.additional-configuration', '').split(/\n/).map { |s| "        #{s}\n" }).join("") %>
     }
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
This commit introduces a new property on the `control` job:
`coredns.additional-configuration`, which lets you shoehorn
"extra" CoreDNS configuration directives into the configmap that the
CoreDNS pods consume.

Fixes #62