### PR TITLE
add opportunity to disable coredns installation

### DIFF
--- a/jobs/control/spec
+++ b/jobs/control/spec
@@ -401,6 +401,13 @@ properties:
 
       This parameter is only used if `cloud-provider.type` is set to "vsphere".
 
+  coredns.enabled:
+    default: true
+    description: |
+      Whether or not to enable the coredns on this cluster.
+      If set to 'true', a default coredns will be provided
+      This parameter should be set to false only if you'll plan to install it externally with specific configuration
+
   dashboard.enabled:
     default: false
     description: |

--- a/jobs/control/templates/bin/post-deploy
+++ b/jobs/control/templates/bin/post-deploy
@@ -64,9 +64,12 @@ echo "[$(date)] $BIN/$$: not bootstrap node; nothing more to do."
 echo "[$(date)] $BIN/$$: applying kube-proxy daemonset configuration..."
 kubectl apply -f $JOB_DIR/k8s/kube-proxy.yml
 
+<% if p('coredns.enabled') %>
 echo "[$(date)] $BIN/$$: applying kube-dns (coredns) configuration..."
 kubectl apply -f $JOB_DIR/k8s/kube-dns.yml
-
+<% else %>
+echo "[$(date)] $BIN/$$: SKIPPING kubernetes-coredns configuration..."
+<% end %>
 (shopt -s nullglob
 for yml in /var/vcap/jobs/*/k8s-init/*.yml; do
   name=${yml%%.yml};         name=${name##*/}


### PR DESCRIPTION
proposal to fix: https://github.com/jhunt/k8s-boshrelease/issues/62
It let user decide to not install coredns by this bosh release.
by default it keeps the same behaviour so install the coredns.